### PR TITLE
Enable rubocop; Bump version; Bump dependencies; Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    json (2.3.0)
-    public_suffix (4.0.6)
-    rotp (5.1.0)
-      addressable (~> 2.5)
-    xmlrpc (0.3.0)
+    json (2.6.3)
+    rotp (6.2.2)
+    webrick (1.8.1)
+    xmlrpc (0.3.2)
+      webrick
 
 PLATFORMS
   ruby
@@ -18,4 +16,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   1.16.1
+   2.3.17

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ domrobot = INWX::Domrobot.new
 result = domrobot.set_language('en').
          use_ote.
          use_json.
-         set_debug(true).
+         show_debug(true).
          login(user, pass)
 
 object = 'domain'

--- a/example.rb
+++ b/example.rb
@@ -20,7 +20,7 @@ result = domrobot.set_language('en').
          # or use the XML-RPC API instead
          # use_xml.
          # output everything you're sending and receiving in JSON pretty print
-         set_debug(true).
+         show_debug(true).
          # optional 3rd parameter available: shared_secret for 2 factor auth
          login(user, pass)
 

--- a/example.rb
+++ b/example.rb
@@ -21,8 +21,8 @@ result = domrobot.set_language('en').
          # use_xml.
          # output everything you're sending and receiving in JSON pretty print
          show_debug(true).
-         # optional 3rd parameter available: shared_secret for 2 factor auth
-         login(user, pass)
+         # optional parameter: shared_secret for 2 factor auth (Base32 secret key)
+         login(username: user, password: pass)
 
 object = 'domain'
 method = 'check'

--- a/inwx-domrobot.gemspec
+++ b/inwx-domrobot.gemspec
@@ -1,15 +1,19 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
-    s.name        = 'inwx-domrobot'
-    s.version     = '3.1'
-    s.date        = '2019-09-12'
-    s.summary     = "INWX Domrobot"
-    s.description = "Ruby Client to easily use the Domrobot API of INWX"
-    s.authors     = ["INWX"]
-    s.email       = 'support@inwx.de'
-    s.files       = ["lib/inwx-domrobot.rb"]
-    s.homepage    = 'https://rubygems.org/gems/inwx-domrobot'
-    s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-    s.add_runtime_dependency 'xmlrpc', '~> 0.3', '>= 0.3.0'
-    s.add_runtime_dependency 'rotp', '~> 5.1', '>= 5.1.0'
-    s.license       = 'MIT'
-  end
+  s.name                  = 'inwx-domrobot'
+  s.version               = '4.0'
+  s.date                  = '2023-05-01'
+  s.summary               = 'INWX Domrobot'
+  s.description           = 'Ruby Client to easily use the Domrobot API of INWX'
+  s.authors               = ['INWX']
+  s.email                 = 'support@inwx.de'
+  s.files                 = ['lib/inwx_domrobot.rb']
+  s.homepage              = 'https://rubygems.org/gems/inwx-domrobot'
+  s.required_ruby_version = '>= 3.0.0'
+  s.license               = 'MIT'
+
+  s.add_runtime_dependency 'json', '~> 2.6.3', '>= 2.6.0'
+  s.add_runtime_dependency 'rotp', '~> 6.2.2', '>= 6.2.0'
+  s.add_runtime_dependency 'xmlrpc', '~> 0.3.2', '>= 0.3.0'
+end

--- a/lib/inwx_domrobot.rb
+++ b/lib/inwx_domrobot.rb
@@ -7,8 +7,10 @@ require 'net/https'
 require 'rotp'
 
 module INWX
+  # Domain Robot class
   class Domrobot
     attr_accessor :client, :cookie, :language, :api_type, :url, :debug
+
     URL_LIVE = 'api.domrobot.com'
     URL_OTE = 'api.ote.domrobot.com'
     TYPE_JSON = '/jsonrpc/'
@@ -47,7 +49,7 @@ module INWX
       self
     end
 
-    def set_debug(value)
+    def show_debug(value)
       self.debug = value
       self
     end
@@ -61,7 +63,7 @@ module INWX
       end
     end
 
-    def login(username = false, password = false, shared_secret = nil)
+    def login(username: false, password: false, shared_secret: nil)
       create_client
 
       params = { user: username, pass: password, lang: language }
@@ -89,10 +91,10 @@ module INWX
 
     def call_xml(object, method, params = {})
       client.cookie = cookie
-      res = client.call(object + '.' + method, params)
+      res = client.call("#{object}.#{method}", params)
 
       save_cookie(client.cookie)
-      debug_sent = { method: object + '.' + method, params: params }
+      debug_sent = { method: "#{object}.#{method}", params: params }
       output_debug(debug_sent.to_json, res.to_json)
 
       res
@@ -101,7 +103,7 @@ module INWX
     def call_json(object, method, params = {})
       req = Net::HTTP::Post.new(api_type)
 
-      json_params = { method: object + '.' + method, params: params }
+      json_params = { method: "#{object}.#{method}", params: params }
 
       req.body = json_params.to_json
       req['Cookie'] = cookie
@@ -118,13 +120,13 @@ module INWX
     end
 
     def output_debug(sent, received)
-      if debug
-        puts 'Sent:'
-        puts JSON.pretty_generate(JSON.parse(sent))
-        puts 'Received:'
-        puts JSON.pretty_generate(JSON.parse(received))
-        puts '-------------------------'
-      end
+      return unless debug
+
+      puts 'Sent:'
+      puts JSON.pretty_generate(JSON.parse(sent))
+      puts 'Received:'
+      puts JSON.pretty_generate(JSON.parse(received))
+      puts '-------------------------'
     end
 
     def get_secret_code(shared_secret)


### PR DESCRIPTION
👋 This PR provides a minimal rubocop config and fixes the gem to ruby versions 3.0 and higher. (<3.0 is EOL).

I also run a very basic rubocop check and adjusted all complaints to have a clean state.
This causes a required change (`set_debug(bool)` to `show_debug(bool)`) - if that's a bad change in your opinion, we can disable it in rubocop so it won't pop up. For this reason I've bumped to mayor 4.0 (breaking change).

Also raised the dependencies to most current possible. Hope that fits.